### PR TITLE
(Após KOT-23) [KOT-24] Criar .env + .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+target
+Dockerfile
+docker-compose.yml
+.vscode
+.idea
+README.MD
+.git
+.gitignore

--- a/docker-compose-env.sh
+++ b/docker-compose-env.sh
@@ -8,4 +8,4 @@ CONFIG=.env.dev
 # CONFIG=.env.prod
 
 COMMAND="docker compose --env-file ./environment/$CONFIG"
-$COMMAND $@
+$COMMAND "$@"

--- a/docker-compose-env.sh
+++ b/docker-compose-env.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Script para selecionar o .env correto no docker compose
+# Exemplo de uso: ./docker-compose-env.sh up --build -d
+
+CONFIG=.env.dev
+# CONFIG=.env.stage
+# CONFIG=.env.prod
+
+COMMAND="docker compose --env-file ./environment/$CONFIG"
+$COMMAND $@

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,4 @@ services:
     environment:
       <<: *config_env
       DB_HOST: db_host
-      PROP1: prop1_teste
+      PROP1: ${ENV_TYPE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
     environment:
       <<: *config_env
       DB_HOST: db_host
+      PROP1: prop1_teste

--- a/environment/.env.dev
+++ b/environment/.env.dev
@@ -1,0 +1,3 @@
+COMPOSE_PROJECT_NAME=career-ladder
+
+ENV_TYPE=dev

--- a/environment/.env.prod
+++ b/environment/.env.prod
@@ -1,0 +1,3 @@
+COMPOSE_PROJECT_NAME=career-ladder
+
+ENV_TYPE=prod

--- a/environment/.env.stage
+++ b/environment/.env.stage
@@ -1,0 +1,3 @@
+COMPOSE_PROJECT_NAME=career-ladder
+
+ENV_TYPE=stage

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,12 @@
+# Execução
+
+## Execução via docker
+
+### Build comum
+
+Para executar o build normal, basta usar o script assitencial `docker-compose-env.sh`
+
+1. Edite o script para usar o .env e docker-compose de sua escolha
+2. Chame a execução do script no terminal passando os parâmetros que complementam o comando do `docker compose`
+    1. Isso garante a flexibilidade do comando `docker compose` original
+    2. Exemplo de uso: `$ bash ./docker-compose-env.sh up --build -d`

--- a/src/main/kotlin/br/com/camelcase/kotlintemplate/controller/SampleController.kt
+++ b/src/main/kotlin/br/com/camelcase/kotlintemplate/controller/SampleController.kt
@@ -10,7 +10,10 @@ class SampleController {
 
     @GetMapping
     fun sampleGet(): String {
-        return "Hello camelCase World!"
+        val primo: String = System.getenv("DB_HOST") ?: ""
+        val seccondo: String = System.getenv("PROP1") ?: ""
+
+        return "Hello camelCase World! $primo || $seccondo"
     }
 
 }

--- a/src/main/kotlin/br/com/camelcase/kotlintemplate/controller/SampleController.kt
+++ b/src/main/kotlin/br/com/camelcase/kotlintemplate/controller/SampleController.kt
@@ -1,10 +1,12 @@
 package br.com.camelcase.kotlintemplate.controller
 
+import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
+@Profile("docker")
 @RequestMapping("/docker")
 class SampleController {
 


### PR DESCRIPTION
Adiciona estrutura básica para uso de .env de acordo com o ambiente, e também um .dockerignore inicial

O .env escolhido pode ser validado pelo endpoint de teste `http://localhost:8000/docker`

Foi adicionado um shell script para facilitar a chamada do .env correto