### PR TITLE
(Após KOT-24) [KOT-34] Configurar uso manual do GraalVM

### DIFF
--- a/docker-compose-env.sh
+++ b/docker-compose-env.sh
@@ -3,9 +3,15 @@
 # Script para selecionar o .env correto no docker compose
 # Exemplo de uso: ./docker-compose-env.sh up --build -d
 
-CONFIG=.env.dev
-# CONFIG=.env.stage
-# CONFIG=.env.prod
+# Nota: Para a execução Native o --build deve ser feito a parte
+# Build Native: mvn -Pnative spring-boot:build-image
 
-COMMAND="docker compose --env-file ./environment/$CONFIG"
-$COMMAND $@
+ENV_VAR=.env.dev
+# ENV_VAR=.env.stage
+# ENV_VAR=.env.prod
+
+COMPOSE_PATH=docker-compose.yml
+# COMPOSE_PATH=docker-compose-native.yml
+
+COMMAND="docker compose -f $COMPOSE_PATH --env-file ./environment/$ENV_VAR"
+$COMMAND "$@"

--- a/docker-compose-native.yml
+++ b/docker-compose-native.yml
@@ -5,10 +5,8 @@ x-common-env: &config_env
 
 services:
   app:
-    image: kotlin-template:latest
+    image: kotlin-template:0.0.1-SNAPSHOT
     container_name: kotlin-template
-    build:
-      context: .
     ports:
       - ${HOST_PORT:-8000}:8000
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ x-common-env: &config_env
 
 services:
   app:
-    image: kotlin-template:latest
+    image: kotlin-template:0.0.1-SNAPSHOT
     container_name: kotlin-template
     build:
       context: .

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,19 @@
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-native</id>
+                        <goals>
+                            <goal>compile-no-fork</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -66,15 +66,6 @@
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>build-native</id>
-                        <goals>
-                            <goal>compile-no-fork</goal>
-                        </goals>
-                        <phase>package</phase>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,10 @@
+# Índice
+
+- [Execução](#execução)
+    - [Execução via docker](#execução-via-docker)
+        - [Build comum](#build-comum)
+        - [Build Native AOT](#build-native-aot)
+
 # Execução
 
 ## Execução via docker
@@ -6,7 +13,18 @@
 
 Para executar o build normal, basta usar o script assitencial `docker-compose-env.sh`
 
-1. Edite o script para usar o .env e docker-compose de sua escolha
+1. Edite o script para usar o `.env` e `docker-compose` de sua escolha
+    1.
+        1. No caso, use o `docker-compose.yml`
 2. Chame a execução do script no terminal passando os parâmetros que complementam o comando do `docker compose`
     1. Isso garante a flexibilidade do comando `docker compose` original
     2. Exemplo de uso: `$ bash ./docker-compose-env.sh up --build -d`
+
+### Build Native AOT
+
+Para executar o build via Spring Native com Ahead of Time:
+
+1. Execute o comando na raiz do projeto: `mvn -Pnative spring-boot:build-image`
+    1. Isso irá iniciar o processo de build que deve durar entre 5 e 10 minutos
+2. Após terminado, use o script de assitência de `docker compose` fazendo uso do `.env` e `docker-compose` apropriados.
+    1. No caso, use o `docker-compose-native.yml`

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,11 @@ Para executar o build normal, basta usar o script assitencial `docker-compose-en
 
 ### Build Native AOT
 
+#### Pré-requisitos:
+
+- Maven 3.8
+- Java JDK 17
+
 Para executar o build via Spring Native com Ahead of Time:
 
 1. Execute o comando na raiz do projeto: `mvn -Pnative spring-boot:build-image`

--- a/src/main/kotlin/br/com/camelcase/kotlintemplate/controller/SampleController.kt
+++ b/src/main/kotlin/br/com/camelcase/kotlintemplate/controller/SampleController.kt
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/japao")
+@RequestMapping("/")
 class SampleController {
 
     @GetMapping

--- a/src/main/kotlin/br/com/camelcase/kotlintemplate/controller/SampleController.kt
+++ b/src/main/kotlin/br/com/camelcase/kotlintemplate/controller/SampleController.kt
@@ -1,13 +1,11 @@
 package br.com.camelcase.kotlintemplate.controller
 
-import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@Profile("docker")
-@RequestMapping("/docker")
+@RequestMapping("/japao")
 class SampleController {
 
     @GetMapping


### PR DESCRIPTION
Cria configuração inicial para execução do Spring Native / GraalVM

Para fazer o build: `mvn -Pnative spring-boot:build-image`
Para subir, usar o script para subir o `docker-compose-native.yml`
